### PR TITLE
Add ESC status feedback

### DIFF
--- a/include/gazebo_mavlink_interface.h
+++ b/include/gazebo_mavlink_interface.h
@@ -147,6 +147,8 @@ namespace mavlink_interface
       void MagnetometerCallback(const gz::msgs::Magnetometer &_msg);
       void GpsCallback(const gz::msgs::NavSat &_msg);
       void SendSensorMessages(const gz::sim::UpdateInfo &_info);
+      void SendStatusMessages(const gz::sim::UpdateInfo &_info,
+          const gz::sim::EntityComponentManager &_ecm);
       void PublishMotorVelocities(gz::sim::EntityComponentManager &_ecm,
           const Eigen::VectorXd &_vels);
       void PublishServoVelocities(const Eigen::VectorXd &_vels);
@@ -202,6 +204,9 @@ namespace mavlink_interface
       bool diff_press_updated_;
 
       double imu_update_interval_ = 0.004; ///< Used for non-lockstep
+
+      uint64_t status_update_interval_ = 200; ///< Interval for sending ESC status / info in ms
+      uint64_t status_last_update_time_ = 0;
 
       gz::math::Vector3d gravity_W_{gz::math::Vector3d(0.0, 0.0, -9.8)};
       gz::math::Vector3d velocity_prev_W_;

--- a/include/mavlink_interface.h
+++ b/include/mavlink_interface.h
@@ -70,6 +70,8 @@ static constexpr auto kDefaultBaudRate = 921600;
 static constexpr ssize_t MAX_SIZE = MAVLINK_MAX_PACKET_LEN + 16;
 static constexpr size_t MAX_TXQ_SIZE = 1000;
 
+static constexpr ssize_t MAX_N_ESCS = 16;
+
 //! Rx packer framing status. (same as @p mavlink::mavlink_framing_t)
 enum class Framing : uint8_t {
 	incomplete = MAVLINK_FRAMING_INCOMPLETE,
@@ -110,6 +112,20 @@ namespace SensorData {
     };
 }
 
+namespace StatusData {
+    struct EscReport {
+        int rpm;
+        double voltage;
+        double current;
+    };
+
+    struct EscStatus {
+        int esc_count;
+        int esc_active_input;
+        struct EscReport esc[MAX_N_ESCS];
+    };
+}
+
 /*
 struct HILData {
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
@@ -143,6 +159,7 @@ public:
     void close();
     void Load();
     void SendSensorMessages(const uint64_t time_usec);
+    void SendEscStatusMessages(const uint64_t time_usec, struct StatusData::EscStatus &status);
     void UpdateBarometer(const SensorData::Barometer &data);
     void UpdateAirspeed(const SensorData::Airspeed &data);
     void UpdateIMU(const SensorData::Imu &data);

--- a/src/gazebo_mavlink_interface.cpp
+++ b/src/gazebo_mavlink_interface.cpp
@@ -26,11 +26,15 @@
 
 #include <gz/plugin/Register.hh>
 #include <gz/sensors/Sensor.hh>
+#include <gz/sim/Joint.hh>
 #include <gz/sim/components/AirPressureSensor.hh>
 #include <gz/sim/components/Magnetometer.hh>
 #include <gz/sim/components/Imu.hh>
 #include <gz/sim/components/Pose.hh>
 #include <gz/transport/Discovery.hh>
+#include <gz/sim/components/Joint.hh>
+
+#define RAD_S_TO_RPM 9.549297
 
 GZ_ADD_PLUGIN(
     mavlink_interface::GazeboMavlinkInterface,
@@ -260,6 +264,12 @@ void GazeboMavlinkInterface::PreUpdate(const gz::sim::UpdateInfo &_info,
 
 void GazeboMavlinkInterface::PostUpdate(const gz::sim::UpdateInfo &_info,
     const gz::sim::EntityComponentManager &_ecm) {
+  // Send back status data (ESCs) after physics update at a certain interval
+  uint64_t current_time = std::chrono::duration_cast<std::chrono::duration<uint64_t>>(_info.simTime * 1e3).count();
+  if (current_time - status_last_update_time_ >= status_update_interval_) {
+    SendStatusMessages(_info, _ecm);
+    status_last_update_time_ = current_time;
+  }
 }
 
 void GazeboMavlinkInterface::PoseCallback(const gz::msgs::Pose_V &_msg){
@@ -423,6 +433,32 @@ void GazeboMavlinkInterface::SendSensorMessages(const gz::sim::UpdateInfo &_info
   imu_data.gyro_b = Eigen::Vector3d(gyro_b.X(), gyro_b.Y(), gyro_b.Z());
   mavlink_interface_->UpdateIMU(imu_data);
   mavlink_interface_->SendSensorMessages(time_usec);
+}
+
+void GazeboMavlinkInterface::SendStatusMessages(const gz::sim::UpdateInfo &_info, const gz::sim::EntityComponentManager &_ecm) {
+  uint64_t time_usec = std::chrono::duration_cast<std::chrono::duration<uint64_t>>(_info.simTime * 1e6).count();
+  struct StatusData::EscStatus status;
+  std::vector<double> vels;
+  char joint_name_c[] = "rotor_0_joint"; // This assumes rotor naming for all model is consistent
+  gz::sim::Entity joint_entity = _ecm.EntityByComponents(gz::sim::components::Name(joint_name_c), gz::sim::components::Joint());;
+
+  double vel;
+  int i = 0;
+  while (joint_entity != gz::sim::kNullEntity) {
+    // Get velocity component data from joint entity
+    std::optional<std::vector<double>> joint_velocity = _ecm.ComponentData<gz::sim::components::JointVelocity>(joint_entity);
+    if (joint_velocity && (*joint_velocity).size() > 0) {
+      status.esc[i].rpm = (*joint_velocity)[0] * RAD_S_TO_RPM;
+    }
+    // Get joint entity
+    i++;
+    joint_name_c[6] = '0' + i;
+    joint_entity = _ecm.EntityByComponents(gz::sim::components::Name(joint_name_c), gz::sim::components::Joint());
+  }
+
+  status.esc_count = i;
+
+  mavlink_interface_->SendEscStatusMessages(time_usec, status);
 }
 
 void GazeboMavlinkInterface::handle_actuator_controls(const gz::sim::UpdateInfo &_info) {

--- a/src/mavlink_interface.cpp
+++ b/src/mavlink_interface.cpp
@@ -347,6 +347,36 @@ void MavlinkInterface::SendSensorMessages(uint64_t time_usec) {
   PushSendMessage(msg_shared);
 }
 
+void MavlinkInterface::SendEscStatusMessages(uint64_t time_usec, struct StatusData::EscStatus &status) {
+  mavlink_esc_status_t esc_status_msg{};
+  mavlink_esc_info_t esc_info_msg{};
+  static constexpr uint8_t batch_size = MAVLINK_MSG_ESC_STATUS_FIELD_RPM_LEN;
+  static uint16_t counter = 0;
+
+  esc_status_msg.time_usec = time_usec;
+  for (int i = 0; i < batch_size; i++) {
+    esc_status_msg.rpm[i] = status.esc[i].rpm;
+
+    esc_info_msg.failure_flags[i] = 0;
+    esc_info_msg.error_count[i] = 0;
+    esc_info_msg.temperature[i] = 20;
+  }
+
+  mavlink_message_t msg;
+  mavlink_msg_esc_status_encode_chan(254, 25, MAVLINK_COMM_0, &msg, &esc_status_msg);
+  auto msg_shared = std::make_shared<mavlink_message_t>(msg);
+  PushSendMessage(msg_shared);
+
+  esc_info_msg.counter = counter++;
+  esc_info_msg.count = status.esc_count;
+  esc_info_msg.connection_type = 0; // TODO: use two highest bits for selected input
+  esc_info_msg.info = (1u << status.esc_count) - 1;
+
+  mavlink_msg_esc_info_encode_chan(254, 25, MAVLINK_COMM_0, &msg, &esc_info_msg);
+  msg_shared = std::make_shared<mavlink_message_t>(msg);
+  PushSendMessage(msg_shared);
+}
+
 void MavlinkInterface::UpdateBarometer(const SensorData::Barometer &data) {
   const std::lock_guard<std::mutex> lock(sensor_msg_mutex_);
   temperature_ = data.temperature;


### PR DESCRIPTION
- remove the dummy esc status feedback previously used in PX4 mavlink/streams/HIL_ACTUATOR_CONTROLS.hpp with real esc status feedback from gazebo model joint status
- paired with https://github.com/tiiuae/px4-firmware/pull/941

Based on @jlaitine recommendation: https://github.com/tiiuae/px4-gzsim-plugins/commit/47ed35075a43e1a6361ea1258618a32716f8fc13

Tested with HITL on MC, FW and VTOL